### PR TITLE
[cpe_chefctl] typo: `conf.empty? && conf.empty?`

### DIFF
--- a/cpe_chefctl/resources/cpe_chefctl.rb
+++ b/cpe_chefctl/resources/cpe_chefctl.rb
@@ -52,7 +52,7 @@ action_class do
     end
 
     conf = node['cpe_chefctl']['config']['chefctl'].reject { |_k, v| v.nil? }
-    return if conf.empty? && conf.empty?
+    return if conf.empty? || conf.nil?
 
     # ToDo - Make this cross platform
     config_path = CPE::Chefctl.config(


### PR DESCRIPTION
Seems to be a typo on L55 (`conf.empty? && conf.empty?`)

This PR, if merged, will modify L55 to read as: `conf.empty? || conf.nil?` which I believe was the original intention.