### PR TITLE
cpe_hostname: Add Windows logic

### DIFF
--- a/cpe_hostname/README.md
+++ b/cpe_hostname/README.md
@@ -13,6 +13,7 @@ Attributes
 * node['cpe_hostname']
 * node['cpe_hostname']['enforce']
 * node['cpe_hostname']['hostname']
+* node['cpe_hostname']['windows_reboot']
 
 Usage
 -----

--- a/cpe_hostname/attributes/default.rb
+++ b/cpe_hostname/attributes/default.rb
@@ -14,4 +14,5 @@
 default['cpe_hostname'] = {
   'enforce' => false,
   'hostname' => nil,
+  'windows_reboot' => false,
 }

--- a/cpe_hostname/resources/cpe_hostname.rb
+++ b/cpe_hostname/resources/cpe_hostname.rb
@@ -24,6 +24,10 @@ action_class do
     shell_out("/usr/sbin/scutil --get #{type}").stdout.to_s.chomp
   end
 
+  def check_hostname_windows
+    shell_out('c:\\Windows\\System32\\HOSTNAME.exe').stdout.to_s.chomp
+  end
+
   def enforce?
     node['cpe_hostname']['enforce']
   end
@@ -66,7 +70,11 @@ action_class do
         end
       end
     elsif node.windows?
-      # TODO: write windows portion
+      hostname 'Resetting hostname' do
+        hostname node['cpe_hostname']['hostname']
+        windows_reboot node['cpe_hostname']['windows_reboot']
+        only_if { check_hostname_windows != node['cpe_hostname']['hostname'] }
+      end
       return
     elsif node.ubuntu?
       # TODO: write ubuntu portion

--- a/cpe_hostname/resources/cpe_hostname.rb
+++ b/cpe_hostname/resources/cpe_hostname.rb
@@ -71,9 +71,9 @@ action_class do
       end
     elsif node.windows?
       hostname 'Resetting hostname' do
-        hostname node['cpe_hostname']['hostname']
+        hostname hostname
         windows_reboot node['cpe_hostname']['windows_reboot']
-        only_if { check_hostname_windows != node['cpe_hostname']['hostname'] }
+        only_if { check_hostname_windows != hostname }
       end
       return
     elsif node.ubuntu?


### PR DESCRIPTION
This PR, if merged, will add functionality to `cpe_hostname` to allow for programmatically changing the hostname of a device if it does not abide by its Chef-defined hostname. It achieves the validation check through a new function, `check_hostname_windows`, which works in tandem with the existing `enforce` method.

Confirmed with @erikng  that the preferred `windows_reboot` resource property value would dictate that the hostname change should be applied at the subsequent reboot (rather than immediately enforcing a reboot and disrupting user-experience).

Questions, comments, concerns, criticisms, and emotional outbursts all welcome. 😎