### PR TITLE
Add linux path to cpe_chefctl

### DIFF
--- a/cpe_chefctl/README.md
+++ b/cpe_chefctl/README.md
@@ -7,7 +7,7 @@ Used to configure [chefctl](https://github.com/facebook/chef-utils/tree/master/c
 
 Attributes
 ----------
-```ruby
+```
 node['cpe_chefctl']
 node['cpe_chefctl']['configure'] # Bool
 node['cpe_chefctl']['remove'] # Bool

--- a/cpe_chefctl/attributes/default.rb
+++ b/cpe_chefctl/attributes/default.rb
@@ -36,6 +36,8 @@ if node.macos?
   path = [
     '/usr/sbin', '/usr/bin', '/sbin', '/bin', '/usr/libexec', '/usr/local/bin'
   ]
+elsif node.linux?
+  path = ['/usr/sbin', '/usr/bin', '/sbin', '/bin']
 else
   path = nil
 end


### PR DESCRIPTION
This ensures linux is happy with chefctl. When daemonized it doesn't get a path anymore ;( 