### PR TITLE
Cookstyle 5.10 fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,20 +91,8 @@ PerceivedComplexity:
 MultilineOperationIndentation:
   Enabled: false
 
-# buggy: https://github.com/bbatsov/rubocop/issues/2639
-Performance/RedundantMatch:
-  Enabled: false
-
 # We don't use CAPS just for constants.
 Style/MutableConstant:
-  Enabled: false
-
-# We'll .times.map all we want.
-Performance/TimesMap:
-  Enabled: false
-
-# https://github.com/bbatsov/rubocop/issues/2676
-Performance/RedundantMerge:
   Enabled: false
 
 # Bug with constants? https://phabricator.fb.com/P56108678
@@ -139,7 +127,7 @@ TrailingCommaInHashLiteral:
 TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Style/SignalException:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # cpe-chef-cookbooks
+
 The Uber cpe-chef-cookbooks (Client Platform Engineering) repo contains a suite of chef cookbooks that we use to manage our fleet of client devices at scale.
 
 ## Dependencies
+
 The following [Facebook cookbooks](https://github.com/facebook/IT-CPE) will more than likely be required for these cookbooks to function. Please check the `metadata.rb` files in each cookbook for a complete list of dependencies.
+
 - cpe_launchd
 - cpe_profiles
 - cpe_remote

--- a/cpe_apple_caching/attributes/default.rb
+++ b/cpe_apple_caching/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_apple_caching
+# Cookbook:: cpe_apple_caching
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_apple_caching/metadata.rb
+++ b/cpe_apple_caching/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_apple_caching'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_apple_caching'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_apple_caching/recipes/default.rb
+++ b/cpe_apple_caching/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_apple_caching
+# Cookbook:: cpe_apple_caching
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_apple_caching/resources/cpe_apple_caching.rb
+++ b/cpe_apple_caching/resources/cpe_apple_caching.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_apple_caching
+# Cookbook:: cpe_apple_caching
 # Resources:: cpe_apple_caching
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chef_handlers/attributes/default.rb
+++ b/cpe_chef_handlers/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: cpe_chef_handlers
 # Attribute:: default
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chef_handlers/metadata.rb
+++ b/cpe_chef_handlers/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_chef_handlers'
 maintainer 'Uber Technologies, Inc'
 maintainer_email 'ts-cpe@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Configures chef handler settings'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_chef_handlers/recipes/default.rb
+++ b/cpe_chef_handlers/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: cpe_chef_handlers
 # Recipe:: default
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chef_handlers/resources/cpe_chef_handlers.rb
+++ b/cpe_chef_handlers/resources/cpe_chef_handlers.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chef_handlers
+# Cookbook:: cpe_chef_handlers
 # Resources:: cpe_chef_handlers
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefclient/attributes/default.rb
+++ b/cpe_chefclient/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: cpe_chefclient
 # Attribute:: default
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefclient/metadata.rb
+++ b/cpe_chefclient/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_chefclient'
 maintainer 'Uber Technologies, Inc'
 maintainer_email 'ts-cpe@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Configures chef client.rb settings'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_chefclient/recipes/default.rb
+++ b/cpe_chefclient/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: cpe_chefclient
 # Recipe:: default
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefclient/resources/cpe_chefctl.rb
+++ b/cpe_chefclient/resources/cpe_chefctl.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chefclient
+# Cookbook:: cpe_chefclient
 # Resources:: cpe_chefclient
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefctl/attributes/default.rb
+++ b/cpe_chefctl/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chefctl
+# Cookbook:: cpe_chefctl
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefctl/files/default/chefctl.rb
+++ b/cpe_chefctl/files/default/chefctl.rb
@@ -2,7 +2,7 @@
 
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 
-# Copyright 2013-present Facebook
+# Copyright:: 2013-present Facebook
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ require 'rubygems'
 
 # We use comments on end blocks to tell what that end statement is ending
 # for sanity sake. This rubocop rule doesn't like this style.
-# rubocop:disable Style/CommentedKeyword
 
 def quit(message, exitcode = 1)
   Chefctl.logger.error(message)

--- a/cpe_chefctl/libraries/cpe_chefctl.rb
+++ b/cpe_chefctl/libraries/cpe_chefctl.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chefctl
+# Cookbook:: cpe_chefctl
 # Libraries:: cpe_chefctl
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefctl/metadata.rb
+++ b/cpe_chefctl/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_chefctl'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Configures chefctl settings'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_chefctl/recipes/default.rb
+++ b/cpe_chefctl/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chefctl
+# Cookbook:: cpe_chefctl
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_chefctl/resources/cpe_chefctl.rb
+++ b/cpe_chefctl/resources/cpe_chefctl.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_chefctl
+# Cookbook:: cpe_chefctl
 # Resources:: cpe_chefctl
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_crashplan/attributes/default.rb
+++ b/cpe_crashplan/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crashplan
+# Cookbook:: cpe_crashplan
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber, Inc.
+# Copyright:: (c) 2019-present, Uber, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_crashplan/metadata.rb
+++ b/cpe_crashplan/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_crashplan'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_crashplan'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 supports 'mac_os_x'

--- a/cpe_crashplan/recipes/default.rb
+++ b/cpe_crashplan/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crashplan
+# Cookbook:: cpe_crashplan
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber, Inc.
+# Copyright:: (c) 2019-present, Uber, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_crashplan/resources/cpe_crashplan_install.rb
+++ b/cpe_crashplan/resources/cpe_crashplan_install.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crashplan
+# Cookbook:: cpe_crashplan
 # Resources:: cpe_crashplan_install
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber, Inc.
+# Copyright:: (c) 2019-present, Uber, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -19,8 +19,6 @@ action :manage do
   install if install? && !uninstall?
   uninstall if uninstall?
 end
-
-# rubocop:disable Metrics/BlockLength
 action_class do
   def install?
     node['cpe_crashplan']['install']

--- a/cpe_crowdstrike_falcon_sensor/attributes/default.rb
+++ b/cpe_crowdstrike_falcon_sensor/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crowdstrike_falcon_sensor
+# Cookbook:: cpe_crowdstrike_falcon_sensor
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_crowdstrike_falcon_sensor/metadata.rb
+++ b/cpe_crowdstrike_falcon_sensor/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_crowdstrike_falcon_sensor'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_crowdstrike_falcon_sensor'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_remote'
 depends 'cpe_launchd'

--- a/cpe_crowdstrike_falcon_sensor/recipes/default.rb
+++ b/cpe_crowdstrike_falcon_sensor/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crowdstrike_falcon_sensor
+# Cookbook:: cpe_crowdstrike_falcon_sensor
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_crowdstrike_falcon_sensor/resources/cpe_crowdstrike_falcon_sensor.rb
+++ b/cpe_crowdstrike_falcon_sensor/resources/cpe_crowdstrike_falcon_sensor.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_crowdstrike_falcon_sensor
+# Cookbook:: cpe_crowdstrike_falcon_sensor
 # Resources:: cpe_crowdstrike_falcon_sensor
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -21,7 +21,7 @@ action :manage do
   uninstall if !install? && uninstall?
 end
 
-action_class do # rubocop:disable Metrics/BlockLength
+action_class do
   def install?
     node['cpe_crowdstrike_falcon_sensor']['install']
   end

--- a/cpe_filebeat/attributes/default.rb
+++ b/cpe_filebeat/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_filebeat
+# Cookbook:: cpe_filebeat
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_filebeat/metadata.rb
+++ b/cpe_filebeat/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_filebeat'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_filebeat'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_remote'
 depends 'cpe_launchd'

--- a/cpe_filebeat/recipes/default.rb
+++ b/cpe_filebeat/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_filebeat
+# Cookbook:: cpe_filebeat
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_filebeat/resources/cpe_filebeat.rb
+++ b/cpe_filebeat/resources/cpe_filebeat.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_filebeat
+# Cookbook:: cpe_filebeat
 # Resources:: cpe_filebeat
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -21,7 +21,7 @@ action :manage do
   cleanup if !install? && !configure?
 end
 
-action_class do # rubocop:disable Metrics/BlockLength
+action_class do
   def install?
     node['cpe_filebeat']['install']
   end

--- a/cpe_gorilla/attributes/default.rb
+++ b/cpe_gorilla/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_gorilla
+# Cookbook:: cpe_gorilla
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_gorilla/metadata.rb
+++ b/cpe_gorilla/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_gorilla'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'This cookbook manages and installs gorilla.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 supports 'windows'

--- a/cpe_gorilla/recipes/default.rb
+++ b/cpe_gorilla/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_gorilla
+# Cookbook:: cpe_gorilla
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_gorilla/resources/cpe_gorilla_configure.rb
+++ b/cpe_gorilla/resources/cpe_gorilla_configure.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_gorilla
+# Cookbook:: cpe_gorilla
 # Resources:: cpe_gorilla_configure
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_hostname/attributes/default.rb
+++ b/cpe_hostname/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_hostname
+# Cookbook:: cpe_hostname
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_hostname/metadata.rb
+++ b/cpe_hostname/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_hostname'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures device hostname'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_hostname/recipes/default.rb
+++ b/cpe_hostname/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_hostname
+# Cookbook:: cpe_hostname
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_hostname/resources/cpe_hostname.rb
+++ b/cpe_hostname/resources/cpe_hostname.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_hostname
+# Cookbook:: cpe_hostname
 # Resources:: cpe_hostname
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_notificationsettings/attributes/default.rb
+++ b/cpe_notificationsettings/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_notificationsettings
+# Cookbook:: cpe_notificationsettings
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/cpe_notificationsettings/metadata.rb
+++ b/cpe_notificationsettings/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_notificationsettings'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_notificationsettings'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_utils'
 depends 'cpe_profiles'

--- a/cpe_notificationsettings/recipes/default.rb
+++ b/cpe_notificationsettings/recipes/default.rb
@@ -1,9 +1,9 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Cookbook Name:: cpe_notificationsettings
+# Cookbook:: cpe_notificationsettings
 # Recipe:: default
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/cpe_notificationsettings/resources/cpe_notificationsettings.rb
+++ b/cpe_notificationsettings/resources/cpe_notificationsettings.rb
@@ -1,9 +1,9 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Cookbook Name:: cpe_notificationsettings
+# Cookbook:: cpe_notificationsettings
 # Resources:: cpe_notificationsettings
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -24,7 +24,6 @@ action :config do
     return
   else
     prefix = node['cpe_profiles']['prefix']
-    # rubocop:disable Style/UnneededCondition
     organization = node['organization'] ? node['organization'] : 'Uber'
     # rubocop:enable Style/UnneededCondition
     notify_profile = {

--- a/cpe_nudge/attributes/default.rb
+++ b/cpe_nudge/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_nudge
+# Cookbook:: cpe_nudge
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_nudge/metadata.rb
+++ b/cpe_nudge/metadata.rb
@@ -3,7 +3,6 @@ maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
 license 'All Rights Reserved'
 description 'This cookbook manages and installs nudge.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_launchd'

--- a/cpe_nudge/recipes/default.rb
+++ b/cpe_nudge/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_nudge
+# Cookbook:: cpe_nudge
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_nudge/resources/cpe_nudge_install.rb
+++ b/cpe_nudge/resources/cpe_nudge_install.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_nudge
+# Cookbook:: cpe_nudge
 # Resources:: cpe_nudge_install
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_nudge/resources/cpe_nudge_json.rb
+++ b/cpe_nudge/resources/cpe_nudge_json.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_nudge
+# Cookbook:: cpe_nudge
 # Resources:: cpe_nudge_json
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_nudge/resources/cpe_nudge_la.rb
+++ b/cpe_nudge/resources/cpe_nudge_la.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_nudge
+# Cookbook:: cpe_nudge
 # Resources:: cpe_nudge_la
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_osquery/attributes/default.rb
+++ b/cpe_osquery/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_osquery
+# Cookbook:: cpe_osquery
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_osquery/metadata.rb
+++ b/cpe_osquery/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_osquery'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures osquery'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_remote'
 depends 'cpe_utils'

--- a/cpe_osquery/recipes/default.rb
+++ b/cpe_osquery/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_osquery
+# Cookbook:: cpe_osquery
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_osquery/resources/cpe_osquery.rb
+++ b/cpe_osquery/resources/cpe_osquery.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_osquery
+# Cookbook:: cpe_osquery
 # Resources:: cpe_osquery
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -21,7 +21,7 @@ action :manage do
   uninstall if !install? && !manage? && uninstall?
 end
 
-action_class do # rubocop:disable Metrics/BlockLength
+action_class do
   def install?
     node['cpe_osquery']['install']
   end

--- a/cpe_sal/attributes/default.rb
+++ b/cpe_sal/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_sal
+# Cookbook:: cpe_sal
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_sal/libraries/cpe_sal.rb
+++ b/cpe_sal/libraries/cpe_sal.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_sal
+# Cookbook:: cpe_sal
 # Libraries:: cpe_sal
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_sal/metadata.rb
+++ b/cpe_sal/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_sal'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_sal'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_launchd'
 depends 'cpe_profiles'

--- a/cpe_sal/recipes/default.rb
+++ b/cpe_sal/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_sal
+# Cookbook:: cpe_sal
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_sal/resources/cpe_sal.rb
+++ b/cpe_sal/resources/cpe_sal.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_sal
+# Cookbook:: cpe_sal
 # Resources:: cpe_sal
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -22,7 +22,7 @@ action :manage do
   cleanup
 end
 
-action_class do # rubocop:disable Metrics/BlockLength
+action_class do
   def create_sal_folder(dir)
     # Create Sal folder
     if node.windows?
@@ -94,7 +94,7 @@ action_class do # rubocop:disable Metrics/BlockLength
   def macos_configure(sal_prefs)
     # Build configuration profile and pass it to cpe_profiles
     prefix = node['cpe_profiles']['prefix']
-    organization = node['organization'] ? node['organization'] : 'Uber' # rubocop:disable  Style/UnneededCondition, Metrics/LineLength
+    organization = node['organization'] ? node['organization'] : 'Uber'
 
     sal_profile = {
       'PayloadIdentifier' => "#{prefix}.sal",

--- a/cpe_shims/attributes/default.rb
+++ b/cpe_shims/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_shims
+# Cookbook:: cpe_shims
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_shims/metadata.rb
+++ b/cpe_shims/metadata.rb
@@ -1,10 +1,9 @@
 name 'cpe_shims'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_shims'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 
 depends 'cpe_utils'

--- a/cpe_shims/recipes/default.rb
+++ b/cpe_shims/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_shims
+# Cookbook:: cpe_shims
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_shims/resources/cpe_shims.rb
+++ b/cpe_shims/resources/cpe_shims.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_shims
+# Cookbook:: cpe_shims
 # Resources:: cpe_shims
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh/attributes/default.rb
+++ b/cpe_ssh/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh
+# Cookbook:: cpe_ssh
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh/libraries/cpe_ssh.rb
+++ b/cpe_ssh/libraries/cpe_ssh.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh
+# Cookbook:: cpe_ssh
 # Libraries:: cpe_ssh
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh/metadata.rb
+++ b/cpe_ssh/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_ssh'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Configures ssh'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_ssh/recipes/default.rb
+++ b/cpe_ssh/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh
+# Cookbook:: cpe_ssh
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh/resources/cpe_ssh.rb
+++ b/cpe_ssh/resources/cpe_ssh.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh
+# Cookbook:: cpe_ssh
 # Resources:: cpe_ssh
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh_server/attributes/default.rb
+++ b/cpe_ssh_server/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh_server
+# Cookbook:: cpe_ssh_server
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh_server/metadata.rb
+++ b/cpe_ssh_server/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_ssh_server'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Configures ssh server'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'

--- a/cpe_ssh_server/recipes/default.rb
+++ b/cpe_ssh_server/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh_server
+# Cookbook:: cpe_ssh_server
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_ssh_server/resources/cpe_ssh_server.rb
+++ b/cpe_ssh_server/resources/cpe_ssh_server.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_ssh_server
+# Cookbook:: cpe_ssh_server
 # Resources:: cpe_ssh_server
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_uiagent/attributes/default.rb
+++ b/cpe_uiagent/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_uiagent
+# Cookbook:: cpe_uiagent
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_uiagent/metadata.rb
+++ b/cpe_uiagent/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_uiagent'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Manages CoreServices UI Agent settings / profile'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/cpe_uiagent/recipes/default.rb
+++ b/cpe_uiagent/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_uiagent
+# Cookbook:: cpe_uiagent
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_uiagent/resources/cpe_uiagent.rb
+++ b/cpe_uiagent/resources/cpe_uiagent.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_uiagent
+# Cookbook:: cpe_uiagent
 # Resources:: cpe_uiagent
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_umad/attributes/default.rb
+++ b/cpe_umad/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_umad
+# Cookbook:: cpe_umad
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_umad/metadata.rb
+++ b/cpe_umad/metadata.rb
@@ -1,9 +1,8 @@
 name 'cpe_umad'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'This cookbook manages and installs umad.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_launchd'

--- a/cpe_umad/recipes/default.rb
+++ b/cpe_umad/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_umad
+# Cookbook:: cpe_umad
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_umad/resources/cpe_umad_agents.rb
+++ b/cpe_umad/resources/cpe_umad_agents.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_umad
+# Cookbook:: cpe_umad
 # Resources:: cpe_umad_agents
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_umad/resources/cpe_umad_install.rb
+++ b/cpe_umad/resources/cpe_umad_install.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_umad
+# Cookbook:: cpe_umad
 # Resources:: cpe_umad_install
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_workspaceone
+# Cookbook:: cpe_workspaceone
 # Attributes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_workspaceone/libraries/hubcli.rb
+++ b/cpe_workspaceone/libraries/hubcli.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_workspaceone
+# Cookbook:: cpe_workspaceone
 # Library:: hubcli
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_workspaceone/metadata.rb
+++ b/cpe_workspaceone/metadata.rb
@@ -1,11 +1,10 @@
 name 'cpe_workspaceone'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Installs/Configures cpe_workspaceone'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 12.14'
 supports 'mac_os_x'
 
 depends 'cpe_remote'

--- a/cpe_workspaceone/recipes/default.rb
+++ b/cpe_workspaceone/recipes/default.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_workspaceone
+# Cookbook:: cpe_workspaceone
 # Recipes:: default
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: cpe_workspaceone
+# Cookbook:: cpe_workspaceone
 # Resources:: cpe_workspaceone
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the
@@ -23,7 +23,7 @@ action :manage do
   uninstall if !install? && uninstall?
 end
 
-action_class do # rubocop:disable Metrics/BlockLength
+action_class do
   def enforce_mdm_profiles?
     node['cpe_workspaceone']['mdm_profiles']['enforce']
   end

--- a/uber_helpers/libraries/macos_utils.rb
+++ b/uber_helpers/libraries/macos_utils.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: uber_helprs
+# Cookbook:: uber_helprs
 # Libraries:: macos_utils
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/uber_helpers/libraries/node_utils.rb
+++ b/uber_helpers/libraries/node_utils.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: uber_helprs
+# Cookbook:: uber_helprs
 # Libraries:: node_utils
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/uber_helpers/libraries/win_utils.rb
+++ b/uber_helpers/libraries/win_utils.rb
@@ -1,10 +1,10 @@
 #
-# Cookbook Name:: uber_helprs
+# Cookbook:: uber_helprs
 # Libraries:: win_utils
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
-# Copyright (c) 2019-present, Uber Technologies, Inc.
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
 # All rights reserved.
 #
 # This source code is licensed under the Apache 2.0 license found in the

--- a/uber_helpers/metadata.rb
+++ b/uber_helpers/metadata.rb
@@ -1,9 +1,8 @@
 name 'uber_helpers'
 maintainer 'Uber Technologies, Inc.'
 maintainer_email 'noreply@uber.com'
-license 'Apache'
+license 'Apache-2.0'
 description 'Uber helper functions and libraries'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_utils'


### PR DESCRIPTION
Fairly minor updates for issues found in Cookstyle 5.10. I also modernized the .rubocop.yml file a bit for cookstyle and newer rubocop releases where some cops have been removed and other renamed.

Note: I updated all the 'Apache' license values to be 'Apache-2.0'. I assume that's what the intention was given the license of the repo. I noticed that most of your file headers are all rights reserved, which is going to cause issues for a lot of people trying to use these cookbooks that require approval from their legal teams. You might want to drop the Apache headers on the recipes in place of the all rights message.

Signed-off-by: Tim Smith <tsmith@chef.io>