### PR TITLE
Add new cpe_environment API cookbook

### DIFF
--- a/cpe_environment/README.md
+++ b/cpe_environment/README.md
@@ -5,6 +5,9 @@ environment variables
 
 Also, a great resource to reference for macOS on this topic: https://scriptingosx.com/2019/06/moving-to-zsh-part-2-configuration-files/
 
+
+*Note*: This currently only supports macOS as the method used on Linux *could* cause issues if `bash` is updated (as we are modifying `bashrc` in this API). Feel free to test and give feedback if you want to use this on Linux.
+
 ## Examples
 
 ```

--- a/cpe_environment/README.md
+++ b/cpe_environment/README.md
@@ -1,0 +1,15 @@
+# cpe_environment
+Manage specific aspects of shell and zsh environments, including PATH and
+environment variables
+
+
+Also, a great resource to reference for macOS on this topic: https://scriptingosx.com/2019/06/moving-to-zsh-part-2-configuration-files/
+
+## Examples
+
+```
+  node.default['cpe_environment']['manage'] = true
+  node.default['cpe_environment']['config']['paths'] << '/my/path/bin'
+  node.default['cpe_environment']['config']['vars']['MYVAR'] = 'something'
+```
+

--- a/cpe_environment/attributes/default.rb
+++ b/cpe_environment/attributes/default.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: cpe_environment
+# Attributes:: default
+#
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+default['cpe_environment'] = {
+  'manage' => false,
+  'config' => {
+    'paths' => [],
+    'vars' => {},
+  },
+}

--- a/cpe_environment/files/default/profile_cpe
+++ b/cpe_environment/files/default/profile_cpe
@@ -1,0 +1,8 @@
+if [ -d /etc/profile.d ]; then
+  for i in /etc/profile.d/*.sh; do
+    if [ -r $i ]; then
+      . $i
+    fi
+  done
+  unset i
+fi

--- a/cpe_environment/libraries/cpe_environment.rb
+++ b/cpe_environment/libraries/cpe_environment.rb
@@ -1,0 +1,45 @@
+module CPE
+  class Environment
+    # This *must* end with a newline character or everything will break.
+    CHEF_MANAGED_TAG = "# Managed by Chef\n"
+
+    def self.chef_managed?(config_path)
+      return false unless ::File.exist?(config_path)
+      read_config(config_path).include?(CHEF_MANAGED_TAG)
+    end
+
+    def self.zsh_chef_managed?(config_path, cpe_config_path)
+      return false unless ::File.exist?(config_path)
+      # Make sure the include lines exists somewhere in the file
+      lines = read_config(config_path)
+      return lines.each_cons(2).any? { |line1, line2| zsh_config_lines(cpe_config_path) == [line1, line2] }
+    end
+
+    def self.profile_chef_managed?(config_path, cpe_profiled_file)
+      return false unless ::File.exist?(config_path)
+      # Make sure the include lines exists somewhere in the file
+      lines = read_config(config_path)
+      return lines.each_cons(2).any? { |line1, line2| bash_config_lines(cpe_profiled_file) == [line1, line2] }
+    end
+
+    def self.read_config(config_path)
+      return [] unless ::File.exist?(config_path)
+      lines = ::File.readlines(config_path)
+      return lines
+    end
+
+    def self.zsh_config_lines(cpe_config_path)
+      [
+        CHEF_MANAGED_TAG,
+        "source #{cpe_config_path}\n",
+      ]
+    end
+
+    def self.bash_config_lines(cpe_profiled_file)
+      [
+        CHEF_MANAGED_TAG,
+        "[ -r #{cpe_profiled_file} ] && . #{cpe_profiled_file}\n",
+      ]
+    end
+  end
+end

--- a/cpe_environment/metadata.rb
+++ b/cpe_environment/metadata.rb
@@ -1,0 +1,13 @@
+name 'cpe_environment'
+maintainer 'Uber Technologies, Inc.'
+maintainer_email 'noreply@uber.com'
+license 'Apache-2.0'
+description 'Configures global shell and zsh environments'
+long_description 'Configures global shell and zsh environments'
+version '0.1.0'
+
+supports 'fedora'
+supports 'mac_os_x'
+supports 'ubuntu'
+
+depends 'cpe_utils'

--- a/cpe_environment/recipes/default.rb
+++ b/cpe_environment/recipes/default.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: cpe_environment
+# Recipe:: default
+#
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+## The method used on linux *may* cause issues with bash updates due to
+## apt not wanting to overwrite the config. See ITECPEP-165
+## Do not scope to linux until this is test/resolved
+return unless node.macos?
+
+cpe_environment_zsh 'Manage Global ZSH Environment'
+cpe_environment_bash 'Manage Global Bash Environment'

--- a/cpe_environment/resources/cpe_environment_bash.rb
+++ b/cpe_environment/resources/cpe_environment_bash.rb
@@ -1,0 +1,134 @@
+#
+# Cookbook Name:: cpe_environment
+# Resource:: cpe_environment_bash
+#
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+resource_name :cpe_environment_bash
+provides :cpe_environment_bash
+default_action :manage
+
+action :manage do
+  configure if node['cpe_environment']['manage']
+  cleanup unless node['cpe_environment']['manage']
+end
+
+action_class do # rubocop:disable Metrics/BlockLength
+  def bash_config_file
+    if node.macos?
+      '/etc/profile'
+    else
+      '/etc/bash.bashrc'
+    end
+  end
+
+  def cpe_profiled_file
+    '/etc/profile_cpe'
+  end
+
+  def cpe_config_file
+    '/etc/profile.d/cpe.sh'
+  end
+
+  def configure
+    # Catalina and higher don't even read /etc/profile, so lets skip this
+    return if node.macos? && node.os_at_least?('10.15')
+
+    # Check config to make sure its not empty
+    cpe_bash_config = node['cpe_environment']['config'].to_h.reject do |_k, v|
+      v.nil? || v.empty?
+    end
+
+    bash_config_set = true
+
+    # Read in /etc/profile on macOS or /etc/bash.bashrc on linux
+    bash_config = CPE::Environment.read_config(bash_config_file)
+
+    if cpe_bash_config.nil? || cpe_bash_config.empty?
+      Chef::Log.warn('config is not populated, skipping configuration')
+      bash_config_set = false
+    end
+
+    # On macOS and ubuntu, it doesn't utilize profile.d by default,
+    # so lets set that up
+    # Place our stub /etc/profile_cpe to include anything inside of profile.d
+    cookbook_file cpe_profiled_file do
+      source 'profile_cpe'
+      owner root_owner
+      group root_group
+      mode '0644'
+    end
+
+    # If there is a valid config and the cpe bash source line does not exist, add it
+    if bash_config_set && !CPE::Environment.profile_chef_managed?(bash_config_file, cpe_profiled_file)
+      bash_config += CPE::Environment.bash_config_lines(cpe_profiled_file)
+    # If there is no longer a config set, make sure to remove include and
+    # delete the config on disk
+    elsif !bash_config_set
+      remove_bash_source(bash_config)
+      # Make sure to delete the file if we no longer have any configs set
+      file cpe_config_file do
+        action :delete
+      end
+    end
+
+    # Manage our include lines in /etc/profile
+    file bash_config_file do
+      owner root_owner
+      group root_group
+      mode '0644'
+      content bash_config.join
+    end
+
+    # /etc/profile.d doesn't exist on macOS by default
+    directory '/etc/profile.d' do
+      owner root_owner
+      group root_group
+    end
+
+    # Place our actual config into /etc/profile.d/cpe.sh
+    template cpe_config_file do
+      only_if { bash_config_set }
+      source 'bash_cpe.erb'
+      owner root_owner
+      group root_group
+      mode '0644'
+      variables(
+        'config' => cpe_bash_config,
+      )
+    end
+  end
+
+  def cleanup
+    # If this is no longer managed, remove configs
+    if CPE::Environment.chef_managed?(bash_config_file)
+      bash_config = CPE::Environment.read_config(bash_config_file)
+      remove_bash_source(bash_config)
+      file bash_config_file do
+        owner root_owner
+        group root_group
+        mode '0644'
+        content bash_config.join
+      end
+    end
+    # Delete the macOS profile.d include file
+    file cpe_profiled_file do
+      action :delete
+    end
+    # Delete the actual cpe.sh from profile.d
+    file cpe_config_file do
+      action :delete
+    end
+  end
+
+  def remove_bash_source(bash_config)
+    tag_index = bash_config.index(CPE::Environment::CHEF_MANAGED_TAG)
+    if tag_index && tag_index >= 0
+      bash_config.slice!(tag_index..tag_index + 1)
+    end
+  end
+end

--- a/cpe_environment/resources/cpe_environment_zsh.rb
+++ b/cpe_environment/resources/cpe_environment_zsh.rb
@@ -1,0 +1,115 @@
+#
+# Cookbook Name:: cpe_environment
+# Resource:: cpe_environment_zsh
+#
+# Copyright:: (c) 2019-present, Uber Technologies, Inc.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+resource_name :cpe_environment_zsh
+provides :cpe_environment_zsh
+default_action :manage
+
+action :manage do
+  configure if node['cpe_environment']['manage']
+  cleanup unless node['cpe_environment']['manage']
+end
+
+action_class do
+  def zsh_config_file
+    if node.macos?
+      '/etc/zshenv'
+    else
+      '/etc/zsh/zshenv'
+    end
+  end
+
+  def cpe_zsh_dir
+    '/etc/zsh'
+  end
+
+  def cpe_config_file
+    "#{cpe_zsh_dir}/cpe"
+  end
+
+  def configure
+    ## Check config to make sure its not empty
+    cpe_zsh_config = node['cpe_environment']['config'].to_h.reject do |_k, v|
+      v.nil? || v.empty?
+    end
+    zsh_config_set = true
+
+    # Read in /etc/zshenv
+    zsh_config = CPE::Environment.read_config(zsh_config_file)
+
+    if cpe_zsh_config.nil? || cpe_zsh_config.empty?
+      Chef::Log.warn('config is not populated, skipping configuration')
+      zsh_config_set = false
+    end
+
+    # If there is a valid config and the cpe zsh source line does not exist, add
+    # it to the list to be included
+    if zsh_config_set && !CPE::Environment.zsh_chef_managed?(zsh_config_file, cpe_config_file)
+      zsh_config += CPE::Environment.zsh_config_lines(cpe_config_file)
+    # If there is no longer a config set, make sure to remove include and
+    # delete the config on disk
+    elsif !zsh_config_set
+      remove_zsh_source(zsh_config)
+      # Make sure to delete the file if we no longer have any configs set
+      file cpe_config_file do
+        action :delete
+      end
+    end
+
+    # Manage our include lines in /etc/zshenv
+    file zsh_config_file do
+      owner root_owner
+      group root_group
+      mode '0644'
+      content zsh_config.join
+    end
+
+    directory cpe_zsh_dir do
+      owner root_owner
+      group root_group
+    end
+
+    template cpe_config_file do
+      only_if { zsh_config_set }
+      source 'zsh_cpe.erb'
+      owner root_owner
+      group root_group
+      mode '0644'
+      variables(
+        'config' => cpe_zsh_config,
+      )
+    end
+  end
+
+  def cleanup
+    # If this is no longer managed, remove directives from ssh_config
+    if CPE::Environment.chef_managed?(zsh_config_file)
+      zsh_config = CPE::Environment.read_config(zsh_config_file)
+      remove_zsh_source(zsh_config)
+      file zsh_config_file do
+        owner root_owner
+        group root_group
+        mode '0644'
+        content zsh_config.join
+      end
+    end
+    # Also delete ssh_config_cpe and known_host_cpe files
+    file cpe_config_file do
+      action :delete
+    end
+  end
+
+  def remove_zsh_source(zsh_config)
+    tag_index = zsh_config.index(CPE::Environment::CHEF_MANAGED_TAG)
+    if tag_index && tag_index >= 0
+      zsh_config.slice!(tag_index..tag_index + 1)
+    end
+  end
+end

--- a/cpe_environment/templates/default/bash_cpe.erb
+++ b/cpe_environment/templates/default/bash_cpe.erb
@@ -1,0 +1,24 @@
+<% unless @config['paths'].nil? || @config['paths'].empty? %>
+ENV_PATHS=<%= @config['paths'].join(':') %>
+   <% if node.macos? %>
+if [[ -z "$PROMPT_COMMAND" ]]; then
+   PROMPT_COMMAND='[[ "$PATH" =~ "$ENV_PATHS" ]] || export PATH="$ENV_PATHS:$PATH"'
+else
+   PROMPT_COMMAND='[[ "$PATH" =~ "$ENV_PATHS" ]] || export PATH="$ENV_PATHS:$PATH"'";$PROMPT_COMMAND"
+fi
+   <% else %>
+preexec() {
+        [[ "$PATH" =~ "$ENV_PATHS" ]] || export PATH="$ENV_PATHS:$PATH"
+}
+preexec_invoke_exec () {
+    [ -n "$COMP_LINE" ] && return  # do nothing if completing
+    preexec
+}
+trap 'preexec_invoke_exec' DEBUG
+   <%- end -%>
+<%- end -%>
+<% unless @config['vars'].nil? %>
+  <% @config['vars'].each do |var,value| %>
+export <%= var %>=<%= value %>
+  <%- end -%>
+<%- end -%>

--- a/cpe_environment/templates/default/zsh_cpe.erb
+++ b/cpe_environment/templates/default/zsh_cpe.erb
@@ -1,0 +1,23 @@
+<% unless @config['paths'].nil? || @config['paths'].empty? %>
+ENV_PATHS=<%= @config['paths'].join(':') %>
+function zsh_load_cpe() {
+  export PATH="$ENV_PATHS:$PATH"
+}
+
+function zsh_unload_cpe() {
+  export PATH=${PATH/$ENV_PATHS:/}
+  export PATH=${PATH/$ENV_PATHS/}
+
+}
+
+autoload -Uz add-zsh-hook
+# for zsh, only enable our hooks before running the command
+# and disable it just before printing the prompt
+add-zsh-hook preexec zsh_load_cpe
+add-zsh-hook precmd zsh_unload_cpe
+<% end -%>
+<% unless @config['vars'].nil? %>
+  <% @config['vars'].each do |var,value| %>
+export <%= var %>=<%= value %>
+  <%- end -%>
+<%- end -%>


### PR DESCRIPTION
This cookbook allows you to manage Bash and ZSH env vars and prepend the system path using magic.