### PR TITLE
cpe_workspaceone updates

### DIFF
--- a/cpe_workspaceone/README.md
+++ b/cpe_workspaceone/README.md
@@ -60,7 +60,9 @@ You can add any arbitrary keys to `node['cpe_workspaceone']['prefs']` to have th
 
 Due to the fact that `cpe_profiles` usually runs last or second to last in a typical run list, a `macos_userdefaults` call is made during the `manage` resource block. This is so if you chose to disable the menubar, it will be honored at the time of agent installation. This call cannot be made while the agent is running as it is unfortunately not honored by Workspace One at this time.
 
-Separate preferences are available through `hubcli config`, and this cookbook manages four of them:
+# CLI Config
+
+Separate preferences are available through `hubcli config`. If node['cpe_workspaceone']['manage_cli'] is true, this cookbook will manage them.
 
 ```
 'cli_prefs' => {
@@ -108,11 +110,15 @@ node.default['cpe_workspaceone']['mdm_profiles']['profiles']['device'] = [
 node.default['cpe_workspaceone']['mdm_profiles']['profiles']['user'] = [
   'ExampleUserScopedProfileName',
 ]
-# Force Profiles
+# Forced Profiles
 Force profiles will always be requested for install from hubcli, even if already installed. This can be useful if the profile install has side effects you wish to [re]trigger, like adding an identity to the keychain.
 
-node['cpe_workspaceone']['mdm_profiles']['profiles']['force'] = [
-  'ExampleForceInstalledProfileName'
+node['cpe_workspaceone']['mdm_profiles']['profiles']['user_forced'] = [
+  'ExampleForceInstalledUserProfileName'
+]
+
+node['cpe_workspaceone']['mdm_profiles']['profiles']['device_forced'] = [
+  'ExampleForceInstalledDeviceProfileName'
 ]
 
 # Manage the preferences of the hub

--- a/cpe_workspaceone/README.md
+++ b/cpe_workspaceone/README.md
@@ -24,6 +24,7 @@ Attributes
 * node['cpe_workspaceone']['mdm_profiles']['profiles']
 * node['cpe_workspaceone']['mdm_profiles']['profiles']['device']
 * node['cpe_workspaceone']['mdm_profiles']['profiles']['user']
+* node['cpe_workspaceone']['mdm_profiles']['profiles']['force']
 * node['cpe_workspaceone']['pkg']
 * node['cpe_workspaceone']['pkg']['allow_downgrade']
 * node['cpe_workspaceone']['pkg']['app_name']
@@ -105,6 +106,12 @@ node.default['cpe_workspaceone']['mdm_profiles']['profiles']['device'] = [
 # User Profiles
 node.default['cpe_workspaceone']['mdm_profiles']['profiles']['user'] = [
   'ExampleUserScopedProfileName',
+]
+# Force Profiles
+Force profiles will always be requested for install from hubcli, even if already installed. This can be useful if the profile install has side effects you wish to [re]trigger, like adding an identity to the keychain.
+
+node['cpe_workspaceone']['mdm_profiles']['profiles']['force'] = [
+  'ExampleForceInstalledProfileName'
 ]
 
 # Manage the preferences of the hub

--- a/cpe_workspaceone/README.md
+++ b/cpe_workspaceone/README.md
@@ -16,6 +16,7 @@ Attributes
 * node['cpe_workspaceone']
 * node['cpe_workspaceone']['cache_invalidation']
 * node['cpe_workspaceone']['hubcli_path']
+* node['cpe_workspaceone']['hubcli_timeout']
 * node['cpe_workspaceone']['install']
 * node['cpe_workspaceone']['manage']
 * node['cpe_workspaceone']['mdm_profiles']
@@ -31,9 +32,15 @@ Attributes
 * node['cpe_workspaceone']['pkg']['pkg_url']
 * node['cpe_workspaceone']['pkg']['receipt']
 * node['cpe_workspaceone']['pkg']['version']
+* node['cpe_workspaceone']['pkg']['headers']
 * node['cpe_workspaceone']['prefs']
 * node['cpe_workspaceone']['uninstall']
 * node['cpe_workspaceone']['use_cache']
+* node['cpe_workspaceone']['cli_prefs']
+* node['cpe_workspaceone']['cli_prefs']['checkin-interval']
+* node['cpe_workspaceone']['cli_prefs']['menubar-icon']
+* node['cpe_workspaceone']['cli_prefs']['sample-interval']
+* node['cpe_workspaceone']['cli_prefs']['transmit-interval']
 
 Usage
 -----
@@ -51,6 +58,21 @@ You can add any arbitrary keys to `node['cpe_workspaceone']['prefs']` to have th
 
 Due to the fact that `cpe_profiles` usually runs last or second to last in a typical run list, a `macos_userdefaults` call is made during the `manage` resource block. This is so if you chose to disable the menubar, it will be honored at the time of agent installation. This call cannot be made while the agent is running as it is unfortunately not honored by Workspace One at this time.
 
+Separate preferences are available through `hubcli config`, and this cookbook manages four of them:
+
+```
+'cli_prefs' => {
+  'checkin-interval' => 60,
+  'menubar-icon' => true,
+  'sample-interval' => 60,
+  'transmit-interval' => 60,
+}
+```
+
+The defaults here are set in case of `nil`. See `hubcli config --help` for more information.
+
+The cookbook intentionally does not manage 'server-url' or 'awcm-url'.
+
 # Package
 By default the package will not be installed. If you need to test a beta release of the agent, be aware that `allow_downgrade` value will not be honored if there is a space in the version number. As of v1910, the beta version string is '19.10 Beta' which causes the built in ruby gem `Gem::Version` to fail.
 
@@ -61,7 +83,7 @@ By default the package will not be installed. If you need to test a beta release
 
 As of v1910, there is only an installation feature. If for some reason you need to remove profiles, you must use the Console API or the Console administration pages.
 
-Please note that as of macOS Catalina, the key `PayloadRemovalDisallowed` is no longer honored at the MDM level if the value is set to `False`. This effectively means that **only** the mdmclient can remove MDM profiles, regardless if a user is an administrator on the dev ice or not.
+Please note that as of macOS Catalina, the key `PayloadRemovalDisallowed` is no longer honored at the MDM level if the value is set to `False`. This effectively means that **only** the mdmclient can remove MDM profiles, regardless if a user is an administrator on the device or not.
 
 ## HubCLI cache
 By default, `cpe_workspaceone` one will create a cache of the json in the default chef cache folder.

--- a/cpe_workspaceone/README.md
+++ b/cpe_workspaceone/README.md
@@ -19,6 +19,7 @@ Attributes
 * node['cpe_workspaceone']['hubcli_timeout']
 * node['cpe_workspaceone']['install']
 * node['cpe_workspaceone']['manage']
+* node['cpe_workspaceone']['manage_cli']
 * node['cpe_workspaceone']['mdm_profiles']
 * node['cpe_workspaceone']['mdm_profiles']['enforce']
 * node['cpe_workspaceone']['mdm_profiles']['profiles']

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -18,6 +18,7 @@ default['cpe_workspaceone'] = {
   'hubcli_timeout' => 300,
   'install' => false,
   'manage' => false,
+  'manage_cli' => false,
   'mdm_profiles' => {
     'enforce' => false,
     'profiles' => {

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -13,8 +13,9 @@
 
 default['cpe_workspaceone'] = {
   'cache_invalidation' => 7200, # seconds, 2 hours
-  'hubcli_path' => '/Applications/Workspace ONE Intelligent Hub.app/Contents/Resources/'\
+  'hubcli_path' => '/Applications/Workspace ONE Intelligent Hub.app/Contents/Resources/',
   'IntelligentHubAgent.app/Contents/Resources/cli/hubcli',
+  'hubcli_timeout' => 300,
   'install' => false,
   'manage' => false,
   'mdm_profiles' => {
@@ -22,6 +23,7 @@ default['cpe_workspaceone'] = {
     'profiles' => {
       'device' => [],
       'user' => [],
+      'force' => [],
     },
   },
   'pkg' => {
@@ -32,10 +34,17 @@ default['cpe_workspaceone'] = {
     'pkg_url' => nil,
     'receipt' => 'com.air-watch.pkg.OSXAgent',
     'version' => nil,
+    'headers' => nil,
   },
   'prefs' => {
     'HubAgentIconVisiblePreference' => nil,
   },
   'uninstall' => false,
   'use_cache' => true,
+  'cli_prefs' => {
+    'checkin-interval' => 60,
+    'menubar-icon' => true,
+    'sample-interval' => 60,
+    'transmit-interval' => 60,
+  }
 }

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -13,7 +13,7 @@
 
 default['cpe_workspaceone'] = {
   'cache_invalidation' => 7200, # seconds, 2 hours
-  'hubcli_path' => '/Applications/Workspace ONE Intelligent Hub.app/Contents/Resources/',
+  'hubcli_path' => '/Applications/Workspace ONE Intelligent Hub.app/Contents/Resources/'\
   'IntelligentHubAgent.app/Contents/Resources/cli/hubcli',
   'hubcli_timeout' => 300,
   'install' => false,

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -25,7 +25,7 @@ default['cpe_workspaceone'] = {
       'device' => [],
       'user' => [],
       'user_forced' => [],
-      'device_forced' => []
+      'device_forced' => [],
     },
   },
   'pkg' => {

--- a/cpe_workspaceone/attributes/default.rb
+++ b/cpe_workspaceone/attributes/default.rb
@@ -24,7 +24,8 @@ default['cpe_workspaceone'] = {
     'profiles' => {
       'device' => [],
       'user' => [],
-      'force' => [],
+      'user_forced' => [],
+      'device_forced' => []
     },
   },
   'pkg' => {

--- a/cpe_workspaceone/libraries/hubcli.rb
+++ b/cpe_workspaceone/libraries/hubcli.rb
@@ -89,7 +89,7 @@ class Chef
         raise "Tried to execute hubcli, hubcli does not exist"
       end
 
-      shell_out(hubcli_cmd(cmd), timeout: node['cpe_workspaceone']['hubcli_timeout'] || 300)
+      shell_out(hubcli_cmd(cmd), timeout: node['cpe_workspaceone']['hubcli_timeout'])
     end
 
     def _get_available_ws1_profiles_list(hubcli_path)

--- a/cpe_workspaceone/libraries/hubcli.rb
+++ b/cpe_workspaceone/libraries/hubcli.rb
@@ -71,10 +71,7 @@ class Chef
     end
 
     def ws1_hubcli_exists
-      @ws1_hubcli_exists ||=
-        begin
-          ::File.exists?(hubcli_path)
-        end
+      @ws1_hubcli_exists ||= ::File.exists?(hubcli_path)
     end
 
     def hubcli_path

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -20,8 +20,8 @@ action :manage do
   # manage needs to go first if you are attempting to hide the agent from appearing showing it's UX to users.
   manage if manage?
   install if install?
-  enforce_mdm_profiles if enforce_mdm_profiles?
   manage_cli_config if manage_cli_config?
+  enforce_mdm_profiles if enforce_mdm_profiles?
   uninstall if !install? && uninstall?
 end
 

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -171,7 +171,9 @@ action_class do # rubocop:disable Metrics/BlockLength
       pkg_url node['cpe_workspaceone']['pkg']['pkg_url'] if node['cpe_workspaceone']['pkg']['pkg_url']
       receipt node['cpe_workspaceone']['pkg']['receipt']
       version ws1_pkg_version
-      headers node['cpe_workspaceone']['pkg']['headers']
+      unless node['cpe_workspaceone']['pkg']['headers'].nil?
+        headers node['cpe_workspaceone']['pkg']['headers']
+      end
     end
   end
 

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -96,7 +96,7 @@ action_class do # rubocop:disable Metrics/BlockLength
       return
     end
 
-    forcelist = node['cpe_workspaceone']['mdm_profiles']['profiles']['force'] || []
+    device_forcelist = node['cpe_workspaceone']['mdm_profiles']['profiles']['device_forced'] || []
 
     # Bail if there are no device attributes
     device_attributes = node.ws1_device_attributes
@@ -116,11 +116,13 @@ action_class do # rubocop:disable Metrics/BlockLength
         execute "Sending #{profile_name} for device installation to Workspace One console" do
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
-          not_if { node.profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
+          not_if { node.profile_installed?('ProfileDisplayName', installed_profile_name) && !device_forcelist.include?(profile_name) }
           timeout node['cpe_workspaceone']['hubcli_timeout']
         end
       end
     end
+
+    user_forcelist = node['cpe_workspaceone']['mdm_profiles']['profiles']['user_forced'] || []
 
     # Loop through the enforced user profiles and compare with available profiles from MDM
     enforced_user_ws1_profiles = node['cpe_workspaceone']['mdm_profiles']['profiles']['user']
@@ -138,7 +140,7 @@ action_class do # rubocop:disable Metrics/BlockLength
         execute "Sending #{profile_name} for user installation to Workspace One console" do
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
-          not_if { node.user_profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
+          not_if { node.user_profile_installed?('ProfileDisplayName', installed_profile_name) && !user_forcelist.include?(profile_name) }
           timeout node['cpe_workspaceone']['hubcli_timeout']
         end
       end

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -112,6 +112,7 @@ action_class do # rubocop:disable Metrics/BlockLength
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
           not_if { node.profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
+          timeout node['cpe_workspaceone']['hubcli_timeout'] || 300
         end
       end
     end
@@ -133,6 +134,7 @@ action_class do # rubocop:disable Metrics/BlockLength
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
           not_if { node.user_profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
+          timeout node['cpe_workspaceone']['hubcli_timeout'] || 300
         end
       end
     end

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -117,7 +117,7 @@ action_class do # rubocop:disable Metrics/BlockLength
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
           not_if { node.profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
-          timeout node['cpe_workspaceone']['hubcli_timeout'] || 300
+          timeout node['cpe_workspaceone']['hubcli_timeout']
         end
       end
     end
@@ -139,7 +139,7 @@ action_class do # rubocop:disable Metrics/BlockLength
           command node.hubcli_cmd("profiles --install #{profile_id}")
           only_if { node.ws1_hubcli_exists } # non-gsub or guard will fail.
           not_if { node.user_profile_installed?('ProfileDisplayName', installed_profile_name) && !forcelist.include?(profile_name) }
-          timeout node['cpe_workspaceone']['hubcli_timeout'] || 300
+          timeout node['cpe_workspaceone']['hubcli_timeout']
         end
       end
     end

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -21,6 +21,7 @@ action :manage do
   manage if manage?
   install if install?
   enforce_mdm_profiles if enforce_mdm_profiles?
+  manage_cli_config if manage_cli_config?
   uninstall if !install? && uninstall?
 end
 
@@ -42,6 +43,10 @@ action_class do # rubocop:disable Metrics/BlockLength
 
   def manage?
     node['cpe_workspaceone']['manage']
+  end
+
+  def manage_cli_config?
+    node['cpe_workspaceone']['manage_cli']
   end
 
   def uninstall?
@@ -189,8 +194,6 @@ action_class do # rubocop:disable Metrics/BlockLength
         end
       end
     end
-
-    manage_cli_config
   end
 
   def uninstall

--- a/cpe_workspaceone/resources/cpe_workspaceone.rb
+++ b/cpe_workspaceone/resources/cpe_workspaceone.rb
@@ -174,33 +174,11 @@ action_class do # rubocop:disable Metrics/BlockLength
 
   def macos_manage
     ws1agent_prefs = node['cpe_workspaceone']['prefs'].reject { |_k, v| v.nil? }
-    prefix = node['cpe_profiles']['prefix']
-    organization = node['organization'] || 'Uber'
-    ws1agent_profile = {
-      'PayloadIdentifier' => "#{prefix}.ws1",
-      'PayloadRemovalDisallowed' => true,
-      'PayloadScope' => 'System',
-      'PayloadType' => 'Configuration',
-      'PayloadUUID' => '605A10E6-9068-4DAA-9AE0-5334E4D49143',
-      'PayloadOrganization' => organization,
-      'PayloadVersion' => 1,
-      'PayloadDisplayName' => 'Workspace One',
-      'PayloadContent' => [],
-    }
     unless ws1agent_prefs.empty?
-      ws1agent_profile['PayloadContent'].push(
-        'PayloadType' => 'com.vmware.hub.agent',
-        'PayloadVersion' => 1,
-        'PayloadIdentifier' => "#{prefix}.ws1",
-        'PayloadUUID' => 'A37C4F5A-07F8-4E66-BA20-9EB808EB3E3D',
-        'PayloadEnabled' => true,
-        'PayloadDisplayName' => 'Workspace One',
-      )
       ws1agent_prefs.each_key do |key|
         next if ws1agent_prefs[key].nil?
-        ws1agent_profile['PayloadContent'][0][key] = ws1agent_prefs[key]
-        # Double tap the preferences since WS1 agent doesn't use profiles atm. Chef 14+
-        if node.at_least?(node['chef_packages']['chef']['version'], '14.0.0')
+        # WS1 agent doesn't use profiles atm. Chef 14+
+        if node.at_least_chef14?
           macos_userdefaults "Configure com.vmware.hub.agent - #{key}" do
             domain '/Library/Preferences/com.vmware.hub.agent'
             key key
@@ -209,7 +187,6 @@ action_class do # rubocop:disable Metrics/BlockLength
         end
       end
     end
-    node.default['cpe_profiles']["#{prefix}.ws1"] = ws1agent_profile
 
     manage_cli_config
   end


### PR DESCRIPTION
This PR can be broken up if that's simpler.

Deltas:

-> Adds support for setting cli preferences (see README)
-> Adds a timeout for all hubcli calls
-> Abstracts non-execute resource hubcli calls to a single method, uses `node.hubcli_cmd` utility to abstract the cmd passed to execute resources
-> Some cleanup (removed extraneous begin/end, eg)
-> Adds support for headers to cpe_workspaceone's call to cpe_remote_pkg
-> Documents changes to API in README