### PR TITLE
exclude Workspace One applied version number in ProfileDisplayName 

### DIFF
--- a/uber_helpers/libraries/node_utils.rb
+++ b/uber_helpers/libraries/node_utils.rb
@@ -60,7 +60,11 @@ class Chef
 
       if profiles.key?('_computerlevel')
         profiles['_computerlevel'].each do |profile|
-          return true if profile[type] == value
+          ls_value = profile[type]
+          if type == 'ProfileDisplayName' && ls_value.include?('/V_')
+            ls_value = ls_value.split('/V_')[0...-1].join('')
+          end
+          return true if ls_value == value
         end
       end
       false
@@ -88,7 +92,11 @@ class Chef
 
       if profiles.key?(node.console_user)
         profiles[node.console_user].each do |profile|
-          return true if profile[type] == value
+          ls_value = profile[type]
+          if type == 'ProfileDisplayName' && ls_value.include?('/V_')
+            ls_value = ls_value.split('/V_')[0...-1].join('')
+          end
+          return true if ls_value == value
         end
       end
       false


### PR DESCRIPTION
So that:

`node.profile_installed?('ProfileDisplayName', 'Super Dooper Profile')` works when Workspace One's generated ProfileDisplayName is actually `Super Dooper Profile/V_17`. 

I think it will make these methods much more useful. The methods still work with non-Workspace One profiles - we check for `/V_n` first. This could fall over if a profile is installed with that substring intentionally through another channel, not by Workspace One.